### PR TITLE
Add repl node testing framework

### DIFF
--- a/lib/token.js
+++ b/lib/token.js
@@ -1,0 +1,24 @@
+// Token Generater file for REPL
+
+var crypto;
+var token;
+
+module.exports.generateToken = function () {
+
+	try {
+		crypto = require('crypto')
+		var secret = require('../config/config').secret
+
+		var timeNow = new Date().getTime()
+		var hash = crypto.createHmac('sha256', secret)
+									.update(timeNow + '')
+									.digest('base64')
+		token = {msg_mac : hash, time_created : timeNow}
+	} catch(err) {
+		console.log('crypto support is disabled')
+	}
+
+	return token
+}
+
+

--- a/package.json
+++ b/package.json
@@ -17,8 +17,12 @@
   },
   "homepage": "https://github.com/alayek/backend-challenges#readme",
   "dependencies": {
+    "colors": "^1.1.2",
     "express": "^4.13.4",
+    "node-dir": "^0.1.12",
     "phantom": "^2.0.10",
+    "replit-client": "^0.3.0",
+    "ws": "^1.1.0",
     "yargs": "^4.6.0"
   }
 }

--- a/python/001_hello_world/hello_world_test.py
+++ b/python/001_hello_world/hello_world_test.py
@@ -1,12 +1,19 @@
-import hello_world as pb
+from hello_world import print_hello
+# The above import should be removed before sending it to Repl
 import sys
-import StringIO
+try:
+    from StringIO import StringIO
+except:
+    from io import StringIO
 
 def test_hello_world():
   stdout = sys.stdout
-  result = StringIO.StringIO()
+  result = StringIO()
   sys.stdout = result
-  pb.print_hello()
+  print_hello()
   sys.stdout = stdout
   output = result.getvalue()
   assert output == "Hello World\n"
+
+## Last line of file should have the testing method signature for Repl to run it
+## test_hello_world()

--- a/test/repl_test.js
+++ b/test/repl_test.js
@@ -1,0 +1,82 @@
+// Repl.it testing with challenges
+// Todo Change it in a mocha test
+
+var ReplitClient = require('replit-client')
+
+var token = require('../lib/token').generateToken()
+// socket creator dependency
+var WebSocket = require('ws')
+var dir = require('node-dir')
+var assert = require('assert')
+var colors = require('colors')
+
+var payload = ''
+var count = 0
+
+var repl = new ReplitClient('api.repl.it', 80, 'python', token, WebSocket)
+console.log('connecting to Python repl ...'.bold)
+repl.connect().then(function () {
+	console.log('connected to repl'.bold)
+	readProgramFiles()
+}, function () {
+	console.log('failed to connect')
+	next()
+})
+
+/**
+ * Read Python program files and send them to Repl
+ * Add every two (test and train files)
+ */
+function readProgramFiles() {
+	dir.readFiles(__dirname + '/../python',{
+		match: /.py$/
+	}, function (err, content, filename, next) {
+		count ++
+		if (err) throw err;
+		console.log('reading ' + filename)
+		// comment the top line to remove imports
+	  payload = payload + "\n# " + content
+	  // hacky solution, should be done better
+	  // after every two files, concatenate and send to payload for testing
+	  if (count % 2 == 0) {
+	  	var fname = filename.substr(filename.lastIndexOf('/') + 1)
+	  	sendPayload(payload, fname, next)
+	  	payload = ''
+	  } else {
+	  	next()
+		}
+	}, function(err, files){
+	  if (err) throw err;
+	  console.log('------------------Reading Complete--------------------')
+	  console.log('disconnecting repl'.bold)
+	  repl.disconnect()
+	})
+}
+
+/**
+ * sendPayload function to evaluate the codes from Repl server
+ */
+function sendPayload(payload, filename, next) {
+	console.log('Sending Payload : ')
+	console.log('-------------------------------------------')
+	console.log(payload.magenta)
+	console.log('-------------------------------------------')
+
+	repl.evaluate(payload,
+		{	stdout: function (out) {
+			console.log(out)
+		}
+	}).then(function (result) {
+		if(result.error) {
+			console.log('error', result.error)
+		}
+		try {
+			assert.strictEqual(result.data, 'None')
+			console.log(filename.green + ' passed REPL checks'.green)
+		} catch(AssertException) {
+			console.log(filename.red + ' failed REPL checks'.red)
+		} finally {
+			next()
+		}
+	})
+}


### PR DESCRIPTION
- Using `replit-client` npm module, made a framework for easy testing
- For every folder, it would concatenate the two files
- To make the tests pass, make sure you checkout `python-solution` branch

This same PR is to be made to `python-solution` branch as well to keep `staging` and `python-solution` have the same testing files. @alayek and @abhisekp please review and suggest whether this would be the best solution 
